### PR TITLE
DCS-1280: Fix script - use id and secret from ui, not api

### DIFF
--- a/scripts/prison-api
+++ b/scripts/prison-api
@@ -109,10 +109,10 @@ set_base_url() {
 
 set_auth_header() {
   local NOMIS_AUTH_URL=${AUTH_URL[$NS_KEY]}
-  local SECRETS="$(kubectl -n ${NAMESPACE} get secret hmpps-welcome-people-into-prison-api -o json)"
+  local SECRETS="$(kubectl -n ${NAMESPACE} get secret hmpps-welcome-people-into-prison-ui -o json)"
   local API_SECRET=$(echo "${SECRETS}" | jq -r ".data.SYSTEM_CLIENT_SECRET | @base64d")
   local API_ID=$(echo "${SECRETS}" | jq -r ".data.SYSTEM_CLIENT_ID | @base64d")
-  local AUTH_BASIC=$(echo -n ${API_ID}:${API_SECRET} | base64 -b0)
+  local AUTH_BASIC=$(echo -n "${API_ID}:${API_SECRET}" | base64 -b0)
   local TOKEN=$(curl -s -X POST "${NOMIS_AUTH_URL}/oauth/token?grant_type=client_credentials&username=$USER_ID" -H 'Content-Type: application/json' -H 'Content-Length: 0' -H "Authorization: Basic ${AUTH_BASIC}" | jq -r '.access_token')
   AUTH_HEADER="Authorization: Bearer $TOKEN"
 }


### PR DESCRIPTION
Since this script was written the oauth client credentials id and secret for WPIP has been moved from the kubernetes api secret to the ui secret.  Update the script to reflect this.
Also add double quotes to variable expansion at line 155 to prevent word splitting.