### PR TITLE
Including a single standard completed journey on the back of the completed move creation.

### DIFF
--- a/lib/data/models.js
+++ b/lib/data/models.js
@@ -239,22 +239,110 @@ module.exports = {
       },
     }),
 
-    start: () => ({
+    start: ({
+      startedAt,
+    }) => ({
       data: {
         type: 'starts',
         attributes: {
-          timestamp: formatISO(new Date()),
-          date: format(new Date(), 'yyyy-MM-dd'),
+          timestamp: formatISO(startedAt),
+          date: format(startedAt, 'yyyy-MM-dd'),
         },
       },
     }),
 
-    complete: () => ({
+    complete: ({
+      completedAt,
+    }) => ({
       data: {
         type: 'completes',
         attributes: {
-          timestamp: formatISO(new Date()),
+          timestamp: formatISO(completedAt),
+          date: format(completedAt, 'yyyy-MM-dd'),
+        },
+      },
+    }),
+  },
+
+  journeys: {
+    proposed: ({
+      fromLocation, toLocation,
+    }) => ({
+      data: {
+        type: 'journeys',
+        attributes: {
+          state: 'proposed',
+          billable: true,
+          vehicle: {
+            id: '12345678ABC',
+            registration: 'AB12 CDE',
+          },
           date: format(new Date(), 'yyyy-MM-dd'),
+          timestamp: formatISO(new Date()),
+        },
+        relationships: {
+          from_location: {
+            data: {
+              id: fromLocation,
+              type: 'locations',
+            },
+          },
+          to_location: {
+            data: {
+              id: toLocation,
+              type: 'locations',
+            },
+          },
+        },
+      },
+    }),
+
+    inProgress: ({
+      occurredAt, journeyId,
+    }) => ({
+      data: {
+        type: 'events',
+        attributes: {
+          occurred_at: occurredAt,
+          recorded_at: occurredAt,
+          notes: 'example note: lorem ipsum dolor sit amet',
+          details: {
+            vehicle_reg: 'AB12 CDE',
+          },
+          event_type: 'JourneyStart',
+        },
+        relationships: {
+          eventable: {
+            data: {
+              type: 'journeys',
+              id: journeyId,
+            },
+          },
+        },
+      },
+    }),
+
+    complete: ({
+      occurredAt, journeyId,
+    }) => ({
+      data: {
+        type: 'events',
+        attributes: {
+          occurred_at: occurredAt,
+          recorded_at: occurredAt,
+          notes: 'example note: lorem ipsum dolor sit amet',
+          details: {
+            vehicle_reg: 'AB12 CDE',
+          },
+          event_type: 'JourneyComplete',
+        },
+        relationships: {
+          eventable: {
+            data: {
+              type: 'journeys',
+              id: journeyId,
+            },
+          },
         },
       },
     }),

--- a/lib/service/basmService.js
+++ b/lib/service/basmService.js
@@ -1,5 +1,5 @@
 const {
-  moves, random, data, profile, syncProfile, randomPerson,
+  moves, journeys, random, data, profile, syncProfile, randomPerson,
 } = require('../data/models');
 
 class BasmService {
@@ -13,33 +13,70 @@ class BasmService {
   }
 
   async createMoveRemand(profileId) {
+    const from = random(data.courts);
     const move = moves.remand({
       profile: profileId,
       date: new Date(),
-      fromLocation: random(data.courts),
+      fromLocation: from,
       toLocation: data.toPrison.value,
     });
-    return this.createMove(move);
+    return this.createMove(move, from);
   }
 
   async createMoveRecall(profileId) {
+    const from = random(data.policeCustodaySuites);
     const move = moves.recall({
       profile: profileId,
       date: new Date(),
-      fromLocation: random(data.policeCustodaySuites),
+      fromLocation: from,
       toLocation: data.toPrison.value,
     });
-    return this.createMove(move);
+    return this.createMove(move, from);
   }
 
-  async createMove(move) {
+  async createMove(move, from) {
     const { id } = await this.api.post('/api/moves', move);
-    await this.api.post(`/api/moves/${id}/start`, moves.start());
-    await this.api.post(`/api/moves/${id}/accept`, moves.accept());
-    await this.api.post(`/api/moves/${id}/complete`, moves.complete());
 
     this.logger.info(`Created move: ${id}`);
+
+    await this.api.post(`/api/moves/${id}/accept`, moves.accept());
+
+    const moveStart = await this.addHours(new Date(), 1);
+    await this.api.post(`/api/moves/${id}/start`, moves.start({
+      startedAt: moveStart,
+    }));
+
+    this.logger.info(`Move ${id} started at: ${moveStart}`);
+
+    const moveComplete = await this.addHours(moveStart, 1);
+    await this.api.post(`/api/moves/${id}/complete`, moves.complete({
+      completedAt: moveComplete,
+    }));
+
+    this.logger.info(`Move ${id} completed at: ${moveComplete}`);
+
+    await this.createJourney(id, from, moveStart, moveComplete);
+
     return id;
+  }
+
+  async createJourney(moveId, from, startedAt, completedAt) {
+    const { id } = await this.api.post(`/api/moves/${moveId}/journeys`, journeys.proposed({
+      fromLocation: from,
+      toLocation: data.toPrison.value,
+    }));
+
+    await this.api.post('/api/events', journeys.inProgress({
+      journeyId: id,
+      occurredAt: startedAt,
+    }));
+
+    await this.api.post('/api/events', journeys.complete({
+      journeyId: id,
+      occurredAt: completedAt,
+    }));
+
+    this.logger.info(`Created completed journey: ${id}`);
   }
 
   async createProfile(personId) {
@@ -91,6 +128,14 @@ class BasmService {
     } = result;
     this.logger.info(`Found person: ${firstNames} ${lastName} (${dateOfBirth}, ${gender})`);
     return id;
+  }
+
+  async addHours(date, hours) {
+    this.logger.info(`date ${date})`);
+
+    const newDate = new Date(date);
+    newDate.setHours(newDate.getHours() + hours);
+    return newDate;
   }
 }
 


### PR DESCRIPTION
This change introduces a the concept of time taken for a move albeit it is pretty crude as it stands.  Prior to this the move start and complete were within seconds of each other which is not a really representative of a real move in Book a secure move.

It also goes a stage further and creates a completed journey with the associated move and also the journeys events, taking the journey from proposed to in_progress and then completed.  Again as above this is an attempt to provide better overall move data.  A move is made up of 1 or more journeys (unless is it cancelled).
